### PR TITLE
Export build generated files

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -374,6 +374,30 @@ or remove the other boards")
         self.__flash(target_path, port)
         logging.info('Board flashed')
 
+    def export(self, output):
+        # Copy existing files
+        targets = [self.signed_hex_path,
+                   self.merged_hex_path,
+                   self.full_hex_path,
+                   self.dfu_package_path]
+        targets = [path for path in targets if os.path.exists(path)]
+
+        if not targets:
+            logging.critical("Error: No target file available")
+            exit()
+
+        # Create folder or abort in case of existing file
+        if not os.path.exists(output):
+            os.makedirs(output)
+        elif not os.path.isdir(output):
+            logging.critical("Error: '{}' is not a directory!".format(output))
+            exit()
+
+        for src in targets:
+            logging.info("'{}' copied to '{}'".format(
+                         src,
+                         shutil.copy(src, output)))
+
     def get_setup_options(self):
         """
         Return build options for setup app
@@ -717,6 +741,12 @@ def flash(mcuboot, board, port):
     KnotSDK().set_board(board)
 
     KnotSDK().flash_prj(mcuboot, port)
+
+
+@cli.command(help='Copy generated files to output directory')
+@click.argument('output')
+def export(output):
+    KnotSDK().export(output)
 
 
 @cli.command(help=('Set default target board. Supported board aliases: \

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -658,7 +658,9 @@ def cli():
 @click.option('-m', '--mcuboot', help='Flash apps and mcuboot after build',
               is_flag=True)
 @click.option('-p', '--port', help='Device port')
-def make(ctx, ot_path, quiet, board, debug, flash, clean, mcuboot, port):
+@click.option('-o', '--output', help='Output path')
+def make(ctx, ot_path, quiet, board, debug,
+         flash, clean, mcuboot, port, output):
     if quiet:
         KnotSDK().set_quiet(True)
 
@@ -692,6 +694,10 @@ def make(ctx, ot_path, quiet, board, debug, flash, clean, mcuboot, port):
     KnotSDK().merge_setup_main()
     KnotSDK().sign_merged()
     KnotSDK().gen_full_img()
+
+    # Export to output path if provided
+    if output:
+        KnotSDK().export(output)
 
     # Flash if flagged to
     if flash or mcuboot:


### PR DESCRIPTION
Allow the user to export the generated output files to the desired directory.

This is particularly useful for when the user wants to flash the board without using our command line interface.