### PR TITLE
Use LEDs to indicate that Bluetooth is running for Setup App

### DIFF
--- a/setup/src/bt_srv.h
+++ b/setup/src/bt_srv.h
@@ -16,3 +16,5 @@
  */
 
 int bt_srv_init(void);
+
+void bt_srv_toggle_advertising(void);

--- a/setup/src/main.c
+++ b/setup/src/main.c
@@ -115,5 +115,6 @@ setup:
 
 	while (1) {
 		bt_srv_toggle_advertising();
+		peripheral_toggle_led();
 	}
 }

--- a/setup/src/main.c
+++ b/setup/src/main.c
@@ -112,4 +112,8 @@ setup:
 		LOG_ERR("Failed to initialize bluetooth");
 		return;
 	}
+
+	while (1) {
+		bt_srv_toggle_advertising();
+	}
 }

--- a/setup/src/peripheral.c
+++ b/setup/src/peripheral.c
@@ -116,3 +116,24 @@ int peripheral_btn_status(void)
 
 	return val;
 }
+
+void peripheral_toggle_led(void)
+{
+	static s64_t last_toggle_time = 0;
+	s64_t current_time;
+	static bool led_state = false;
+
+	/* Wait for toggle time */
+	current_time = k_uptime_get();
+	if (current_time - last_toggle_time < LED_TOGGLE_PERIOD)
+		return;
+
+	/* Toggle led */
+	gpio_pin_write(gpio_led_dev[0], gpio_led_pin[0],  led_state);
+	gpio_pin_write(gpio_led_dev[1], gpio_led_pin[1], !led_state);
+
+	led_state = !led_state;
+
+	/* Update time */
+	last_toggle_time = current_time;
+}

--- a/setup/src/peripheral.h
+++ b/setup/src/peripheral.h
@@ -13,6 +13,7 @@
 
 int peripheral_init(void);
 int peripheral_btn_status(void);
+void peripheral_toggle_led(void);
 
 enum {
 	PERIPHERAL_BTN_PRESSED = 0,


### PR DESCRIPTION
Use LEDs to indicate that Bluetooth is running for Setup App.

This is necessary so the user will be able to differ a Thing on Setup state from a powered off Thing.

Closes #25.