### PR TITLE
docker: Initial Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,172 @@
+# This file is derived from the original Dockerfile for Zephyr Project's
+# Docker image. The original Dockerfile can be found at Zephyr Project's
+# github page.
+#   Github repository: https://github.com/zephyrproject-rtos/docker-image
+#   Commit: c2a7da444d34c598af113168ae3fcc5ffb1c8d0e
+#
+# Changes:
+#	Remove VNC support.
+# 	Cloning Zephyr and KNoT used git repositories.
+#	Always using CESAR's Zephyr Project git fork.
+#	Install Zephyr-KNoT-SDK requirements.
+#	Allow user to use the desired folder as the current working directory.
+#	Install Segger Jlink drivers from an external file.
+
+FROM ubuntu:18.04
+
+ARG ZSDK_VERSION=0.10.0
+ARG GCC_ARM_NAME=gcc-arm-none-eabi-7-2018-q2-update
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN dpkg --add-architecture i386 && \
+	apt-get -y update && \
+	apt-get -y upgrade && \
+	apt-get install --no-install-recommends -y \
+	gnupg \
+	ca-certificates && \
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+	echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
+	apt-get -y update && \
+	apt-get install --no-install-recommends -y \
+	autoconf \
+	automake \
+	build-essential \
+	ccache \
+	device-tree-compiler \
+	dfu-util \
+	doxygen \
+	file \
+	g++ \
+	gcc \
+	gcc-multilib \
+	gcovr \
+	git \
+	git-core \
+	gperf \
+	gtk-sharp2 \
+	iproute2 \
+	lcov \
+	libglib2.0-dev \
+	libgtk2.0-0 \
+	libpcap-dev \
+	libsdl2-dev:i386 \
+	libtool \
+	locales \
+	make \
+	mono-complete \
+	net-tools \
+	ninja-build \
+	openbox \
+	pkg-config \
+	python3-pip \
+	python3-ply \
+	python3-setuptools \
+	python-xdg \
+	qemu \
+	socat \
+	sudo \
+	texinfo \
+	valgrind \
+	wget \
+	x11vnc \
+	xvfb \
+	xz-utils && \
+	wget -O dtc.deb http://security.ubuntu.com/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb && \
+	dpkg -i dtc.deb && \
+	wget -O renode.deb https://github.com/renode/renode/releases/download/v1.6.2/renode_1.6.2_amd64.deb && \
+	apt install -y ./renode.deb && \
+	rm dtc.deb renode.deb && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN wget -q "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}-setup.run" && \
+	sh "zephyr-sdk-${ZSDK_VERSION}-setup.run" --quiet -- -d /opt/toolchains/zephyr-sdk-${ZSDK_VERSION} && \
+	rm "zephyr-sdk-${ZSDK_VERSION}-setup.run"
+
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/${GCC_ARM_NAME}-linux.tar.bz2  && \
+	tar xf ${GCC_ARM_NAME}-linux.tar.bz2 && \
+	rm -f ${GCC_ARM_NAME}-linux.tar.bz2 && \
+	mv ${GCC_ARM_NAME} /opt/toolchains/${GCC_ARM_NAME}
+
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2-Linux-x86_64.sh && \
+	chmod +x cmake-3.13.2-Linux-x86_64.sh && \
+	./cmake-3.13.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && \
+	rm -f ./cmake-3.13.2-Linux-x86_64.sh
+
+
+RUN useradd -m -G plugdev user \
+	&& echo 'user ALL = NOPASSWD: ALL' > /etc/sudoers.d/user \
+	&& chmod 0440 /etc/sudoers.d/user
+
+# Set the locale
+ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}
+ENV GNUARMEMB_TOOLCHAIN_PATH=/opt/toolchains/${GCC_ARM_NAME}
+ENV PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
+ENV DISPLAY=:0
+
+# Get KNoT's Zephyr
+ENV ZEPHYR_BASE=/home/user/zephyrproject/zephyr
+RUN git clone -b zephyr-knot-v1.14.0 --single-branch --depth=1 https://github.com/CESARBR/zephyr.git ${ZEPHYR_BASE}
+RUN pip3 install wheel && \
+	pip3 install -r ${ZEPHYR_BASE}/scripts/requirements.txt && \
+	pip3 install west &&\
+	pip3 install sh
+
+# WEST
+RUN (cd ${ZEPHYR_BASE}/.. && west init -l ${ZEPHYR_BASE} && west update)
+
+ENV KNOT_BASE=/home/user/knot-sdk
+
+# Install Segger JLink using external file
+ARG jlink_installer_path
+COPY ${jlink_installer_path} jlink.deb
+RUN dpkg -i jlink.deb && rm jlink.deb
+
+# Download and install nRF5 Command line tools
+RUN wget -qO nrf5_tools.tar https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF5-command-line-tools/sw/nRF-Command-Line-Tools_9_8_1_Linux-x86_64.tar && \
+	mkdir nrf5_tools && \
+	tar -xf nrf5_tools.tar -C nrf5_tools && \
+	rm -f nrf5_tools.tar && \
+	ln -s `readlink -f nrf5_tools/nrfjprog/nrfjprog` /usr/local/bin/nrfjprog && \
+	ln -s `readlink -f nrf5_tools/mergehex/mergehex` /usr/local/bin/mergehex
+
+# KNoT Protocol
+RUN apt install automake libtool
+RUN git clone -b master --single-branch --depth=1 https://github.com/CESARBR/knot-protocol-source.git && \
+	(cd knot-protocol-source && \
+	./bootstrap-configure && \
+	make) && \
+	rm -rf knot-protocol-source
+
+# KNoT SDK
+RUN git clone -b master --single-branch --depth=1 https://github.com/CESARBR/zephyr-knot-sdk.git ${KNOT_BASE} && \
+	pip3 install -r ${KNOT_BASE}/scripts/requirements.txt && \
+	rm -f requirements.txt
+
+# Use cli.py as an installed script
+RUN ln -s ${KNOT_BASE}/scripts/cli.py /usr/local/bin/knot
+
+# Clone target OpenThread branch
+ARG OT_BASE=/home/user/openthread
+RUN git clone -b master --single-branch https://github.com/openthread/openthread.git ${OT_BASE} && \
+	(cd ${OT_BASE} && \
+	git checkout -b knot_hash f9d757a161fea4775d033a1ce88cf7962fe24a93)
+
+RUN knot ot-path ${OT_BASE}
+
+RUN chown -R user:user /home/user
+
+RUN usermod -a -G dialout user
+
+USER user
+
+CMD ["/bin/bash"]
+
+WORKDIR /workdir
+VOLUME ["/workdir"]

--- a/docker/LICENSE.txt
+++ b/docker/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,94 @@
+# Zephyr KNoT SDK Docker environment
+
+The Docker image can be used to ease building new apps using a pre-configured
+environment.
+
+It supports Docker for Mac, Linux and Windows.
+
+To build or run the image, you have to [install Docker](https://docs.docker.com/install/).
+
+## Building image
+
+If you want build the Docker image, it is necessary to provide a Segger J-Link
+`.deb` installer for Linux path.
+
+It can be downloaded at [Segger J-Link download page](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack).
+
+Copy the installer to the Dockerfile folder.
+
+```shell
+cp <PATH to downloaded file> jlink.deb
+```
+
+Build it by the tag `zephyr-knot-sdk` and passing the path to the jlink installer `deb` file.
+
+```shell
+docker build --tag=zephyr-knot-sdk --build-arg jlink_installer_path=jlink.deb .
+```
+
+## Running the container
+
+Run the latest image version at CESAR's Docker Hub and pass the current working
+directory as the project folder.
+This folder shall contain all your project files.
+
+At your project folder, run:
+
+```shell
+docker run -ti -v $(pwd)/:/workdir cesarbr/zephyr-knot-sdk:latest
+```
+
+If you want to run it from an image you built, replace `cesarbr/zephyr-knot-sdk:latest`
+by the tag you used.
+
+Compile for your target board
+
+```shell
+container> $ knot make -b {BOARD}
+```
+
+## Exporting generated files
+
+Export the generated files to your project's directory
+```shell
+container> $ knot export /workdir/output
+```
+
+The generated files can now be flashed to your device by using the
+[nRF Connect for Desktop](https://www.nordicsemi.com/?sc_itemid=%7B49D2264D-62FD-4C16-811F-88B477833C5D%7D) and its
+[Programmer app](https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_introduction.html).
+
+## Flashing on Linux
+
+If using a Linux device with the necessary drivers for flashing the boards,
+you may give USB access to the container.
+
+Before proceeding, make sure that you added your user to the dialout group.
+
+```shell
+sudo usermod -a -G dialout `whoami`
+```
+
+You can now access the container using the host `/dev` directory.
+
+```shell
+docker run -ti --privileged -v /dev:/dev -v $(pwd)/:/workdir cesarbr/zephyr-knot-sdk:latest
+```
+
+This will allow you to use the `--flash` flag to flash after building the project.
+
+```shell
+container> $ knot make -b {BOARD} --flash
+```
+
+## Using other knot commands
+
+When inside the Docker container, you may use any KNoT command from the command line interface.
+
+To get a list of all available commands, run:
+
+```
+container> $ knot --help
+```
+
+More info is available at the [Zephy KNoT SDK README](https://github.com/CESARBR/zephyr-knot-sdk/).


### PR DESCRIPTION
Create Dockerfile derived from the original Dockerfile for Zephyr
Project's Docker image.

Changes:
	Remove VNC support.
 	Cloning Zephyr and KNoT used git repositories.
	Always using CESAR's Zephyr Project git fork.
	Install Zephyr-KNoT-SDK requirements.
	Allow user to use desired folder as current working directory.
	Install Segger Jlink drivers from an external file.

The Segger Jlink drivers path has to be provided during compilation.

Add LICENSE.txt file as the original project is protected by Apache
License.

Closes: #27

Signed-off-by: jvccCESAR <jvcc@cesar.org.br>