### PR TITLE
docker: hooks: Ignore caching when auto-building

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --no-cache -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Add a hook to be used by Docker Hub to overwrite the build command
to ignore caching.

Closes #37 

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>