### PR TITLE
setup: gatt_inet6: Remove GATT encrypt

### DIFF
--- a/setup/src/gatt_inet6.c
+++ b/setup/src/gatt_inet6.c
@@ -83,8 +83,8 @@ static struct bt_gatt_attr config_gatt_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(&config_service_uuid),
 	BT_GATT_CHARACTERISTIC(&peer_ipv6_uuid.uuid,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_READ_ENCRYPT |
-			       BT_GATT_PERM_WRITE_ENCRYPT |
+			       BT_GATT_PERM_READ |
+			       BT_GATT_PERM_WRITE |
 			       BT_GATT_PERM_PREPARE_WRITE,
 			       read_ipv6, write_ipv6, peer_ipv6),
 };


### PR DESCRIPTION
Remove encrypt protection from ipv6 service's characteristics.

This is necessary for devices that do not support bounding to connect
to the system.

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>