### PR TITLE
Remove proxy reference from API

### DIFF
--- a/apps/analog-alert/src/analog.c
+++ b/apps/analog-alert/src/analog.c
@@ -64,14 +64,14 @@ void setup(void)
 	adc_channel_setup(adc_dev, &channel_cfg);
 
 	/* Send readings */
-	knot_proxy_register(0, "Norm", KNOT_TYPE_ID_ANGLE,
-			    KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_ANGLE_DEGREE,
-			    NULL, read_adc);
-	knot_proxy_set_config(0,
-			      KNOT_EVT_FLAG_TIME, 20,
-			      KNOT_EVT_FLAG_LOWER_THRESHOLD, LOWER_LIMIT,
-			      KNOT_EVT_FLAG_UPPER_THRESHOLD, UPPER_LIMIT,
-			      NULL);
+	knot_data_register(0, "Norm", KNOT_TYPE_ID_ANGLE,
+			   KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_ANGLE_DEGREE,
+			   NULL, read_adc);
+	knot_data_config(0,
+			 KNOT_EVT_FLAG_TIME, 20,
+			 KNOT_EVT_FLAG_LOWER_THRESHOLD, LOWER_LIMIT,
+			 KNOT_EVT_FLAG_UPPER_THRESHOLD, UPPER_LIMIT,
+			 NULL);
 }
 
 int16_t adc_buffer;

--- a/apps/analog-alert/src/analog.c
+++ b/apps/analog-alert/src/analog.c
@@ -66,7 +66,7 @@ void setup(void)
 	/* Send readings */
 	knot_data_register(0, "Norm", KNOT_TYPE_ID_ANGLE,
 			   KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_ANGLE_DEGREE,
-			   NULL, read_adc);
+			   &adc_norm, sizeof(adc_norm), NULL, read_adc);
 	knot_data_config(0,
 			 KNOT_EVT_FLAG_TIME, 20,
 			 KNOT_EVT_FLAG_LOWER_THRESHOLD, LOWER_LIMIT,

--- a/apps/analog-alert/src/analog.c
+++ b/apps/analog-alert/src/analog.c
@@ -37,9 +37,14 @@ float adc_norm;
 static struct device *gpiob;		/* GPIO device */
 static struct device *adc_dev;
 
-static void read_adc(struct knot_proxy *proxy)
+/*
+ * Write not supported.
+ * This function signs that it is not possible for KNoT machine to write values
+ * to the target variable, keeping it read-only.
+ */
+int write_fail(int id)
 {
-	knot_proxy_value_set_basic(proxy, &adc_norm);
+	return KNOT_CALLBACK_FAIL;
 }
 
 static const struct adc_channel_cfg channel_cfg = {
@@ -66,7 +71,7 @@ void setup(void)
 	/* Send readings */
 	knot_data_register(0, "Norm", KNOT_TYPE_ID_ANGLE,
 			   KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_ANGLE_DEGREE,
-			   &adc_norm, sizeof(adc_norm), NULL, read_adc);
+			   &adc_norm, sizeof(adc_norm), write_fail, NULL);
 	knot_data_config(0,
 			 KNOT_EVT_FLAG_TIME, 20,
 			 KNOT_EVT_FLAG_LOWER_THRESHOLD, LOWER_LIMIT,

--- a/apps/digital-counter/src/counter.c
+++ b/apps/digital-counter/src/counter.c
@@ -70,18 +70,18 @@ void setup(void)
 	counter = 0;	/* Reset counter */
 
 	/* KNoT config - LED*/
-	knot_proxy_register(0, "LED", KNOT_TYPE_ID_SWITCH,
-			    KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			    NULL, read_led);
-	knot_proxy_set_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
+	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
+			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			   NULL, read_led);
+	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 	/* KNoT config - Counter*/
-	knot_proxy_register(1, "Counter", KNOT_TYPE_ID_TEMPERATURE,
-		            KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		            write_counter, read_counter);
-	knot_proxy_set_config(1,
-			      KNOT_EVT_FLAG_TIME, 30,
-			      KNOT_EVT_FLAG_UPPER_THRESHOLD, 10, NULL);
+	knot_data_register(1, "Counter", KNOT_TYPE_ID_TEMPERATURE,
+		           KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+		           write_counter, read_counter);
+	knot_data_config(1,
+			 KNOT_EVT_FLAG_TIME, 30,
+			 KNOT_EVT_FLAG_UPPER_THRESHOLD, 10, NULL);
 }
 
 int64_t last_toggle_time = 0;

--- a/apps/digital-counter/src/counter.c
+++ b/apps/digital-counter/src/counter.c
@@ -36,22 +36,6 @@ int counter;			/* Events counter */
 struct device *gpio_led;		/* GPIO device */
 struct device *gpio_sensor;		/* GPIO device */
 
-void read_led(struct knot_proxy *proxy)
-{
-	knot_proxy_value_set_basic(proxy, &led);
-}
-
-void write_counter(struct knot_proxy *proxy)
-{
-	knot_proxy_value_get_basic(proxy, &counter);
-	LOG_INF("Value for counter changed to %d", counter);
-}
-
-void read_counter(struct knot_proxy *proxy)
-{
-	knot_proxy_value_set_basic(proxy, &counter);
-}
-
 void setup(void)
 {
 	/* Peripherals control */
@@ -72,14 +56,14 @@ void setup(void)
 	/* KNoT config - LED*/
 	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			   &led, sizeof(led), NULL, read_led);
+			   &led, sizeof(led), NULL, NULL);
 	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 	/* KNoT config - Counter*/
 	knot_data_register(1, "Counter", KNOT_TYPE_ID_TEMPERATURE,
 			   KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
 			   &counter, sizeof(counter),
-			   write_counter, read_counter);
+			   NULL, NULL);
 	knot_data_config(1,
 			 KNOT_EVT_FLAG_TIME, 30,
 			 KNOT_EVT_FLAG_UPPER_THRESHOLD, 10, NULL);

--- a/apps/digital-counter/src/counter.c
+++ b/apps/digital-counter/src/counter.c
@@ -72,13 +72,14 @@ void setup(void)
 	/* KNoT config - LED*/
 	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			   NULL, read_led);
+			   &led, sizeof(led), NULL, read_led);
 	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 	/* KNoT config - Counter*/
 	knot_data_register(1, "Counter", KNOT_TYPE_ID_TEMPERATURE,
-		           KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		           write_counter, read_counter);
+			   KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			   &counter, sizeof(counter),
+			   write_counter, read_counter);
 	knot_data_config(1,
 			 KNOT_EVT_FLAG_TIME, 30,
 			 KNOT_EVT_FLAG_UPPER_THRESHOLD, 10, NULL);

--- a/apps/hello-dongle/src/hello.c
+++ b/apps/hello-dongle/src/hello.c
@@ -52,7 +52,7 @@ void setup(void)
 	/* KNoT config */
 	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			   write_led, read_led);
+			   &led, sizeof(led), write_led, read_led);
 
 	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 

--- a/apps/hello-dongle/src/hello.c
+++ b/apps/hello-dongle/src/hello.c
@@ -50,11 +50,11 @@ void setup(void)
 	gpio_pin_configure(gpio_led, LED_PIN, GPIO_DIR_OUT);
 
 	/* KNoT config */
-	knot_proxy_register(0, "LED", KNOT_TYPE_ID_SWITCH,
-			    KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			    write_led, read_led);
+	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
+			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			   write_led, read_led);
 
-	knot_proxy_set_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
+	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 }
 

--- a/apps/hello-dongle/src/hello.c
+++ b/apps/hello-dongle/src/hello.c
@@ -30,17 +30,12 @@ LOG_MODULE_REGISTER(hello, LOG_LEVEL_DBG);
 bool led = true; 			/* Tracked value */
 struct device *gpio_led;		/* GPIO device */
 
-void write_led(struct knot_proxy *proxy)
+int write_led(int id)
 {
-	knot_proxy_value_get_basic(proxy, &led);
 	LOG_INF("Value for led changed to %d", led);
-
 	gpio_pin_write(gpio_led, LED_PIN, !led); /* Led is On at LOW */
-}
 
-void read_led(struct knot_proxy *proxy)
-{
-	knot_proxy_value_set_basic(proxy, &led);
+	return KNOT_CALLBACK_SUCCESS;
 }
 
 void setup(void)
@@ -52,8 +47,7 @@ void setup(void)
 	/* KNoT config */
 	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			   &led, sizeof(led), write_led, read_led);
-
+			   &led, sizeof(led), write_led, NULL);
 	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 }

--- a/apps/hello/src/hello.c
+++ b/apps/hello/src/hello.c
@@ -89,7 +89,7 @@ void setup(void)
 	/* BUTTON - Sent after change */
 	if (knot_proxy_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 		      KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-		      changed_led, poll_led) == NULL) {
+		      changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}
 	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_CHANGE, NULL);

--- a/apps/hello/src/hello.c
+++ b/apps/hello/src/hello.c
@@ -57,29 +57,14 @@ static void val_update(struct k_timer *timer_id)
 K_TIMER_DEFINE(val_update_timer, val_update, NULL);
 #endif
 
-static void changed_led(struct knot_proxy *proxy)
+int changed_led(int id)
 {
-	knot_proxy_value_get_basic(proxy, &led);
 	LOG_INF("Value for led changed to %d", led);
 
 #if CONFIG_BOARD_NRF52840_PCA10056
 	gpio_pin_write(gpiob, LED_PIN, !led); /* Led is On at LOW */
 #endif
-}
-
-static void poll_led(struct knot_proxy *proxy)
-{
-	/* Pushing status to remote */
-	bool res;
-	res = knot_proxy_value_set_basic(proxy, &led);
-
-	/* Notify if sent */
-	if (res) {
-		if (led)
-			LOG_INF("Sending value true for led");
-		else
-			LOG_INF("Sending value false for led");
-	}
+	return KNOT_CALLBACK_SUCCESS;
 }
 
 void setup(void)
@@ -90,7 +75,7 @@ void setup(void)
 	if (knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
 			       &led, sizeof(led),
-			       changed_led, poll_led) < 0) {
+			       changed_led, NULL) < 0) {
 		LOG_ERR("LED failed to register");
 	}
 	success = knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);

--- a/apps/hello/src/hello.c
+++ b/apps/hello/src/hello.c
@@ -87,12 +87,12 @@ void setup(void)
 	bool success;
 
 	/* BUTTON - Sent after change */
-	if (knot_proxy_register(0, "LED", KNOT_TYPE_ID_SWITCH,
-		      KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-		      changed_led, poll_led) < 0) {
+	if (knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
+			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			       changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}
-	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
+	success = knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 	if (!success)
 		LOG_ERR("LED failed to configure");
 

--- a/apps/hello/src/hello.c
+++ b/apps/hello/src/hello.c
@@ -89,6 +89,7 @@ void setup(void)
 	/* BUTTON - Sent after change */
 	if (knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			       &led, sizeof(led),
 			       changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}

--- a/apps/multisensor/src/multisensor.c
+++ b/apps/multisensor/src/multisensor.c
@@ -148,6 +148,7 @@ void setup(void)
 	/* THERMO - Sent every 5 seconds or at high temperatures */
 	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
 			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			       &thermo, sizeof(thermo),
 			       changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
@@ -161,6 +162,7 @@ void setup(void)
 	/* BUTTON - Sent after change */
 	if (knot_data_register(1, "LED", KNOT_TYPE_ID_SWITCH,
 			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			       &led, sizeof(led),
 			       changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}
@@ -171,6 +173,7 @@ void setup(void)
 	/* PLATE - Sent every 10 seconds */
 	if (knot_data_register(2, "PLATE", KNOT_TYPE_ID_NONE,
 			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
+			       &plate, sizeof(plate),
 			       plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}

--- a/apps/multisensor/src/multisensor.c
+++ b/apps/multisensor/src/multisensor.c
@@ -148,7 +148,7 @@ void setup(void)
 	/* THERMO - Sent every 5 seconds or at high temperatures */
 	if (knot_proxy_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
 		      KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		      changed_thermo, poll_thermo) == NULL) {
+		      changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
 	success = knot_proxy_set_config(0,
@@ -161,7 +161,7 @@ void setup(void)
 	/* BUTTON - Sent after change */
 	if (knot_proxy_register(1, "LED", KNOT_TYPE_ID_SWITCH,
 		      KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-		      changed_led, poll_led) == NULL) {
+		      changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}
 	success = knot_proxy_set_config(1, KNOT_EVT_FLAG_CHANGE, NULL);
@@ -171,7 +171,7 @@ void setup(void)
 	/* PLATE - Sent every 10 seconds */
 	if (knot_proxy_register(2, "PLATE", KNOT_TYPE_ID_NONE,
 		      KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
-		      plate_changed, random_plate) == NULL) {
+		      plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}
 	success = knot_proxy_set_config(2, KNOT_EVT_FLAG_TIME, 10, NULL);

--- a/apps/multisensor/src/multisensor.c
+++ b/apps/multisensor/src/multisensor.c
@@ -146,35 +146,35 @@ void setup(void)
 	bool success;
 
 	/* THERMO - Sent every 5 seconds or at high temperatures */
-	if (knot_proxy_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
-		      KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		      changed_thermo, poll_thermo) < 0) {
+	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
+			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			       changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
-	success = knot_proxy_set_config(0,
-					KNOT_EVT_FLAG_TIME, 5,
-					KNOT_EVT_FLAG_UPPER_THRESHOLD,
-					high_temp, NULL);
+	success = knot_data_config(0,
+				   KNOT_EVT_FLAG_TIME, 5,
+				   KNOT_EVT_FLAG_UPPER_THRESHOLD,
+				   high_temp, NULL);
 	if (!success)
 		LOG_ERR("THERMO failed to configure");
 
 	/* BUTTON - Sent after change */
-	if (knot_proxy_register(1, "LED", KNOT_TYPE_ID_SWITCH,
-		      KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-		      changed_led, poll_led) < 0) {
+	if (knot_data_register(1, "LED", KNOT_TYPE_ID_SWITCH,
+			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			       changed_led, poll_led) < 0) {
 		LOG_ERR("LED failed to register");
 	}
-	success = knot_proxy_set_config(1, KNOT_EVT_FLAG_CHANGE, NULL);
+	success = knot_data_config(1, KNOT_EVT_FLAG_CHANGE, NULL);
 	if (!success)
 		LOG_ERR("LED failed to configure");
 
 	/* PLATE - Sent every 10 seconds */
-	if (knot_proxy_register(2, "PLATE", KNOT_TYPE_ID_NONE,
-		      KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
-		      plate_changed, random_plate) < 0) {
+	if (knot_data_register(2, "PLATE", KNOT_TYPE_ID_NONE,
+			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
+			       plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}
-	success = knot_proxy_set_config(2, KNOT_EVT_FLAG_TIME, 10, NULL);
+	success = knot_data_config(2, KNOT_EVT_FLAG_TIME, 10, NULL);
 	if (!success)
 		LOG_ERR("PLATE failed to configure");
 

--- a/apps/multisensor/src/multisensor.c
+++ b/apps/multisensor/src/multisensor.c
@@ -60,73 +60,23 @@ static void val_update(struct k_timer *timer_id)
 K_TIMER_DEFINE(val_update_timer, val_update, NULL);
 #endif
 
-static void changed_thermo(struct knot_proxy *proxy)
+int read_thermo(int id)
 {
-	u8_t id;
-
-	id = knot_proxy_get_id(proxy);
-	knot_proxy_value_get_basic(proxy, &thermo);
-
-	LOG_INF("Value for thermo with id %u changed to %d", id, thermo);
-}
-
-static void poll_thermo(struct knot_proxy *proxy)
-{
-	u8_t id;
-	bool res;
-
-	id = knot_proxy_get_id(proxy);
-	/* Get current temperature from actual object */
 	thermo++;
-
-	/* Pushing temperature to remote */
-	res = knot_proxy_value_set_basic(proxy, &thermo);
-
-	/* Notify if sent */
-	if (res)
-		LOG_INF("Sending value %d for thermo with id %u", thermo, id);
-
+	return KNOT_CALLBACK_SUCCESS;
 }
 
-static void changed_led(struct knot_proxy *proxy)
+int changed_led(int id)
 {
-	knot_proxy_value_get_basic(proxy, &led);
-	LOG_INF("Value for led changed to %d", led);
-
 #if CONFIG_BOARD_NRF52840_PCA10056
 	gpio_pin_write(gpiob, LED_PIN, !led); /* Led is On at LOW */
 #endif
+	return KNOT_CALLBACK_SUCCESS;
 }
 
-static void poll_led(struct knot_proxy *proxy)
+int random_plate(int id)
 {
-	/* Pushing status to remote */
-	bool res;
-	res = knot_proxy_value_set_basic(proxy, &led);
-
-	/* Notify if sent */
-	if (res) {
-		if (led)
-			LOG_INF("Sending value true for led");
-		else
-			LOG_INF("Sending value false for led");
-	}
-}
-
-static void plate_changed(struct knot_proxy *proxy)
-{
-	int len;
-
-	if (knot_proxy_value_get_string(proxy, plate, sizeof(plate), &len))
-		LOG_INF("Plate changed %s", plate);
-}
-
-static void random_plate(struct knot_proxy *proxy)
-{
-	u8_t id;
 	int num;
-	bool res;
-	id = knot_proxy_get_id(proxy);
 
 	num = (sys_rand32_get() % 7);
 	plate[3] = '0' + num;
@@ -134,52 +84,30 @@ static void random_plate(struct knot_proxy *proxy)
 	plate[5] = '2' + num;
 	plate[6] = '3' + num;
 
-	res = knot_proxy_value_set_string(proxy, plate, sizeof(plate));
-
-	/* Notify if sent */
-	if (res)
-		LOG_INF("Sent plate %s", plate);
+	return KNOT_CALLBACK_SUCCESS;
 }
 
 void setup(void)
 {
-	bool success;
-
 	/* THERMO - Sent every 5 seconds or at high temperatures */
-	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
-			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-			       &thermo, sizeof(thermo),
-			       changed_thermo, poll_thermo) < 0) {
-		LOG_ERR("THERMO_0 failed to register");
-	}
-	success = knot_data_config(0,
-				   KNOT_EVT_FLAG_TIME, 5,
-				   KNOT_EVT_FLAG_UPPER_THRESHOLD,
-				   high_temp, NULL);
-	if (!success)
-		LOG_ERR("THERMO failed to configure");
+	knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
+			   KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			   &thermo, sizeof(thermo), NULL, read_thermo);
+	knot_data_config(0,
+			 KNOT_EVT_FLAG_TIME, 5,
+			 KNOT_EVT_FLAG_UPPER_THRESHOLD, high_temp, NULL);
 
 	/* BUTTON - Sent after change */
-	if (knot_data_register(1, "LED", KNOT_TYPE_ID_SWITCH,
-			       KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			       &led, sizeof(led),
-			       changed_led, poll_led) < 0) {
-		LOG_ERR("LED failed to register");
-	}
-	success = knot_data_config(1, KNOT_EVT_FLAG_CHANGE, NULL);
-	if (!success)
-		LOG_ERR("LED failed to configure");
+	knot_data_register(1, "LED", KNOT_TYPE_ID_SWITCH,
+			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			   &led, sizeof(led), changed_led, NULL);
+	knot_data_config(1, KNOT_EVT_FLAG_CHANGE, NULL);
 
 	/* PLATE - Sent every 10 seconds */
-	if (knot_data_register(2, "PLATE", KNOT_TYPE_ID_NONE,
-			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
-			       &plate, sizeof(plate),
-			       plate_changed, random_plate) < 0) {
-		LOG_ERR("PLATE failed to register");
-	}
-	success = knot_data_config(2, KNOT_EVT_FLAG_TIME, 10, NULL);
-	if (!success)
-		LOG_ERR("PLATE failed to configure");
+	knot_data_register(2, "PLATE", KNOT_TYPE_ID_NONE,
+			   KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
+			   &plate, sizeof(plate), NULL, random_plate);
+	knot_data_config(2, KNOT_EVT_FLAG_TIME, 10, NULL);
 
 	/* Peripherals control */
 #if CONFIG_BOARD_NRF52840_PCA10056

--- a/apps/plate/src/plate.c
+++ b/apps/plate/src/plate.c
@@ -58,12 +58,12 @@ void setup(void)
 	bool success;
 
 	/* PLATE - Sent every 10 seconds */
-	if (knot_proxy_register(0, "PLATE", KNOT_TYPE_ID_NONE,
-		      KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
-		      plate_changed, random_plate) < 0) {
+	if (knot_data_register(0, "PLATE", KNOT_TYPE_ID_NONE,
+			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
+			       plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}
-	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 10, NULL);
+	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 10, NULL);
 	if (!success)
 		LOG_ERR("PLATE failed to configure");
 }

--- a/apps/plate/src/plate.c
+++ b/apps/plate/src/plate.c
@@ -25,20 +25,9 @@ LOG_MODULE_REGISTER(plate, LOG_LEVEL_DBG);
 /* Tracked value */
 static char plate[] = "KNT0000";
 
-static void plate_changed(struct knot_proxy *proxy)
+int random_plate(int id)
 {
-	int len;
-
-	if (knot_proxy_value_get_string(proxy, plate, sizeof(plate), &len))
-		LOG_INF("Plate changed %s", plate);
-}
-
-static void random_plate(struct knot_proxy *proxy)
-{
-	u8_t id;
 	int num;
-	bool res;
-	id = knot_proxy_get_id(proxy);
 
 	num = (sys_rand32_get() % 7);
 	plate[3] = '0' + num;
@@ -46,11 +35,7 @@ static void random_plate(struct knot_proxy *proxy)
 	plate[5] = '2' + num;
 	plate[6] = '3' + num;
 
-	res = knot_proxy_value_set_string(proxy, plate, sizeof(plate));
-
-	/* Notify if sent */
-	if (res)
-		LOG_INF("Sent plate %s", plate);
+	return KNOT_CALLBACK_SUCCESS;
 }
 
 void setup(void)
@@ -61,7 +46,7 @@ void setup(void)
 	if (knot_data_register(0, "PLATE", KNOT_TYPE_ID_NONE,
 			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
 			       &plate, sizeof(plate),
-			       plate_changed, random_plate) < 0) {
+			       NULL, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}
 	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 10, NULL);

--- a/apps/plate/src/plate.c
+++ b/apps/plate/src/plate.c
@@ -60,6 +60,7 @@ void setup(void)
 	/* PLATE - Sent every 10 seconds */
 	if (knot_data_register(0, "PLATE", KNOT_TYPE_ID_NONE,
 			       KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
+			       &plate, sizeof(plate),
 			       plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}

--- a/apps/plate/src/plate.c
+++ b/apps/plate/src/plate.c
@@ -60,7 +60,7 @@ void setup(void)
 	/* PLATE - Sent every 10 seconds */
 	if (knot_proxy_register(0, "PLATE", KNOT_TYPE_ID_NONE,
 		      KNOT_VALUE_TYPE_RAW, KNOT_UNIT_NOT_APPLICABLE,
-		      plate_changed, random_plate) == NULL) {
+		      plate_changed, random_plate) < 0) {
 		LOG_ERR("PLATE failed to register");
 	}
 	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 10, NULL);

--- a/apps/tank/src/tank.c
+++ b/apps/tank/src/tank.c
@@ -70,6 +70,7 @@ void setup(void)
 	/* VOLUME - Sent every 5 seconds or at low volumes */
 	if (knot_data_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
 			       KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
+			       &volume, sizeof(volume),
 			       changed_volume, poll_volume) < 0) {
 		LOG_ERR("VOLUME_0 failed to register");
 	}

--- a/apps/tank/src/tank.c
+++ b/apps/tank/src/tank.c
@@ -70,7 +70,7 @@ void setup(void)
 	/* VOLUME - Sent every 5 seconds or at low volumes */
 	if (knot_proxy_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
 		      KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
-		      changed_volume, poll_volume) == NULL) {
+		      changed_volume, poll_volume) < 0) {
 		LOG_ERR("VOLUME_0 failed to register");
 	}
 	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 5, NULL);

--- a/apps/tank/src/tank.c
+++ b/apps/tank/src/tank.c
@@ -28,58 +28,19 @@
 LOG_MODULE_REGISTER(tank, LOG_LEVEL_DBG);
 
 /* Tracked value */
-static float volume = 10000;
-
-static void changed_volume(struct knot_proxy *proxy)
-{
-	u8_t id;
-
-	id = knot_proxy_get_id(proxy);
-	knot_proxy_value_get_basic(proxy, &volume);
-
-	LOG_INF("Value for volume with id %u changed", id);
-}
-
-static void poll_volume(struct knot_proxy *proxy)
-{
-	u8_t id;
-	bool res;
-	int int_part;
-	int dec_part;
-
-	id = knot_proxy_get_id(proxy);
-	/* Get current volume from actual object */
-	int_part = (sys_rand32_get() % 10000);
-	dec_part = (sys_rand32_get() % 1000);
-	volume = int_part + dec_part/1000.0;
-
-	/* Pushing volume to remote */
-	res = knot_proxy_value_set_basic(proxy, &volume);
-
-	/* Notify if sent */
-	if (res)
-		LOG_INF("Sending value %d.%d for tank volume with id %u",
-		 int_part, dec_part, id);
-
-}
+float volume = 10000;
 
 void setup(void)
 {
-	bool success;
-
 	/* VOLUME - Sent every 5 seconds or at low volumes */
-	if (knot_data_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
-			       KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
-			       &volume, sizeof(volume),
-			       changed_volume, poll_volume) < 0) {
-		LOG_ERR("VOLUME_0 failed to register");
-	}
-	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 5, NULL);
-	if (!success)
-		LOG_ERR("VOLUME failed to configure");
+	knot_data_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
+			   KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
+			   &volume, sizeof(volume), NULL, NULL);
 
+	knot_data_config(0, KNOT_EVT_FLAG_TIME, 5, NULL);
 }
 
 void loop(void)
 {
+	volume += -5 + (sys_rand32_get() % 100001)/10000.0; // Add random value
 }

--- a/apps/tank/src/tank.c
+++ b/apps/tank/src/tank.c
@@ -68,12 +68,12 @@ void setup(void)
 	bool success;
 
 	/* VOLUME - Sent every 5 seconds or at low volumes */
-	if (knot_proxy_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
-		      KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
-		      changed_volume, poll_volume) < 0) {
+	if (knot_data_register(0, "VOLUME", KNOT_TYPE_ID_VOLUME,
+			       KNOT_VALUE_TYPE_FLOAT, KNOT_UNIT_VOLUME_L,
+			       changed_volume, poll_volume) < 0) {
 		LOG_ERR("VOLUME_0 failed to register");
 	}
-	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 5, NULL);
+	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 5, NULL);
 	if (!success)
 		LOG_ERR("VOLUME failed to configure");
 

--- a/apps/thermo/src/thermo.c
+++ b/apps/thermo/src/thermo.c
@@ -61,7 +61,7 @@ void setup(void)
 	/* THERMO - Sent every 5 seconds or at high temperatures */
 	if (knot_proxy_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
 		      KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		      changed_thermo, poll_thermo) == NULL) {
+		      changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
 	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 5,

--- a/apps/thermo/src/thermo.c
+++ b/apps/thermo/src/thermo.c
@@ -61,6 +61,7 @@ void setup(void)
 	/* THERMO - Sent every 5 seconds or at high temperatures */
 	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
 			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			       &thermo, sizeof(thermo),
 			       changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}

--- a/apps/thermo/src/thermo.c
+++ b/apps/thermo/src/thermo.c
@@ -59,12 +59,12 @@ void setup(void)
 	bool success;
 
 	/* THERMO - Sent every 5 seconds or at high temperatures */
-	if (knot_proxy_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
-		      KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
-		      changed_thermo, poll_thermo) < 0) {
+	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
+			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
+			       changed_thermo, poll_thermo) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
-	success = knot_proxy_set_config(0, KNOT_EVT_FLAG_TIME, 5,
+	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 5,
 					KNOT_EVT_FLAG_UPPER_THRESHOLD,
 					high_temp, NULL);
 	if (!success)

--- a/apps/thermo/src/thermo.c
+++ b/apps/thermo/src/thermo.c
@@ -23,36 +23,8 @@
 LOG_MODULE_REGISTER(thermo, LOG_LEVEL_DBG);
 
 /* Tracked value */
-static int thermo = 0;
-static int high_temp = 100000;
-
-static void changed_thermo(struct knot_proxy *proxy)
-{
-	u8_t id;
-
-	id = knot_proxy_get_id(proxy);
-	knot_proxy_value_get_basic(proxy, &thermo);
-
-	LOG_INF("Value for thermo with id %u changed to %d", id, thermo);
-}
-
-static void poll_thermo(struct knot_proxy *proxy)
-{
-	u8_t id;
-	bool res;
-
-	id = knot_proxy_get_id(proxy);
-	/* Get current temperature from actual object */
-	thermo++;
-
-	/* Pushing temperature to remote */
-	res = knot_proxy_value_set_basic(proxy, &thermo);
-
-	/* Notify if sent */
-	if (res)
-		LOG_INF("Sending value %d for thermo with id %u", thermo, id);
-
-}
+int thermo = 0;
+int high_temp = 100000;
 
 void setup(void)
 {
@@ -62,7 +34,7 @@ void setup(void)
 	if (knot_data_register(0, "THERMO", KNOT_TYPE_ID_TEMPERATURE,
 			       KNOT_VALUE_TYPE_INT, KNOT_UNIT_TEMPERATURE_C,
 			       &thermo, sizeof(thermo),
-			       changed_thermo, poll_thermo) < 0) {
+			       NULL, NULL) < 0) {
 		LOG_ERR("THERMO_0 failed to register");
 	}
 	success = knot_data_config(0, KNOT_EVT_FLAG_TIME, 5,
@@ -75,4 +47,5 @@ void setup(void)
 
 void loop(void)
 {
+	thermo++;
 }

--- a/apps/toggle/src/toggle.c
+++ b/apps/toggle/src/toggle.c
@@ -47,6 +47,7 @@ void setup(void)
 	/* KNoT config */
 	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
 			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			   &toggle, sizeof(toggle),
 			   write_led, NULL);
 
 	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);

--- a/apps/toggle/src/toggle.c
+++ b/apps/toggle/src/toggle.c
@@ -45,11 +45,11 @@ void setup(void)
 	gpio_pin_configure(gpio_led, TOGGLE_PIN, GPIO_DIR_OUT);
 
 	/* KNoT config */
-	knot_proxy_register(0, "LED", KNOT_TYPE_ID_SWITCH,
-			    KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
-			    write_led, NULL);
+	knot_data_register(0, "LED", KNOT_TYPE_ID_SWITCH,
+			   KNOT_VALUE_TYPE_BOOL, KNOT_UNIT_NOT_APPLICABLE,
+			   write_led, NULL);
 
-	knot_proxy_set_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
+	knot_data_config(0, KNOT_EVT_FLAG_CHANGE, NULL);
 
 }
 

--- a/apps/toggle/src/toggle.c
+++ b/apps/toggle/src/toggle.c
@@ -30,12 +30,12 @@ LOG_MODULE_REGISTER(toggle, LOG_LEVEL_DBG);
 bool toggle = true; 			/* Tracked value */
 struct device *gpio_led;		/* GPIO device */
 
-void write_led(struct knot_proxy *proxy)
+int write_led(int id)
 {
-	knot_proxy_value_get_basic(proxy, &toggle);
 	LOG_INF("Value for toggle changed to %d", toggle);
-
 	gpio_pin_write(gpio_led, TOGGLE_PIN, !toggle); /* Led is On at LOW */
+
+	return KNOT_CALLBACK_SUCCESS;
 }
 
 void setup(void)

--- a/core/src/knot.h
+++ b/core/src/knot.h
@@ -5,20 +5,24 @@
  */
 
 /*
+ * Callback functions that can be called so the data item value can be updated
+ * before/after being read/written.
+ */
+#define KNOT_CALLBACK_SUCCESS	 0  // Able to read/write value
+#define KNOT_CALLBACK_FAIL	-1  // Failed to read/write value
+
+typedef int (*knot_callback_t) (int id);
+
+/*
  * Similar to Arduino:
  * setup() is called once and loop() is always called at idle state.
- * Sensors and actuactors should be registered at setup() function
- * definition and loop() must NOT be blooking.
+ * Sensors and actuators should be registered at setup() function
+ * definition and loop() must NOT be blocking.
  *
  * setup() and loop() must be defined at user app context.
  */
 void setup(void);
 void loop(void);
-
-/* Proxy: Virtual representation of the remote device */
-struct knot_proxy;
-
-typedef void (*knot_callback_t) (struct knot_proxy *proxy);
 
 /* Set knot to track and update data items */
 int knot_data_register(u8_t id, const char *name,
@@ -35,19 +39,3 @@ int knot_data_register(u8_t id, const char *name,
  * This function must end with NULL
  */
 bool knot_data_config(u8_t id, ...);
-
-/* Proxy properties */
-u8_t knot_proxy_get_id(struct knot_proxy *proxy);
-
-/* Proxy helpers to get or set sensor data at the remote */
-bool knot_proxy_value_set_basic(struct knot_proxy *proxy,
-				const void *value);
-bool knot_proxy_value_set_string(struct knot_proxy *proxy,
-				 const char *value, int len);
-
-bool knot_proxy_value_get_basic(struct knot_proxy *proxy,
-				void *value);
-bool knot_proxy_value_get_string(struct knot_proxy *proxy,
-				 char *value, int len, int *olen);
-
-

--- a/core/src/knot.h
+++ b/core/src/knot.h
@@ -20,14 +20,11 @@ struct knot_proxy;
 
 typedef void (*knot_callback_t) (struct knot_proxy *proxy);
 
-/*
- * Creates & tracks device changes on a remote device (cloud).
- * Returns the registered id. Returns a negative number if failed.
- */
+/* Set knot to track and update data items */
 int knot_data_register(u8_t id, const char *name,
-		       u16_t type_id, u8_t value_type,
-		       u8_t unit, knot_callback_t write_cb,
-		       knot_callback_t read_cb);
+		       u16_t type_id, u8_t value_type, u8_t unit,
+		       void *target, size_t target_len,
+		       knot_callback_t write_cb, knot_callback_t read_cb);
 
 /*
  * This fuction configures which events should send proxy value to cloud

--- a/core/src/knot.h
+++ b/core/src/knot.h
@@ -24,10 +24,10 @@ typedef void (*knot_callback_t) (struct knot_proxy *proxy);
  * Creates & tracks device changes on a remote device (cloud).
  * Returns the registered id. Returns a negative number if failed.
  */
-int knot_proxy_register(u8_t id, const char *name,
-			u16_t type_id, u8_t value_type,
-			u8_t unit, knot_callback_t write_cb,
-			knot_callback_t read_cb);
+int knot_data_register(u8_t id, const char *name,
+		       u16_t type_id, u8_t value_type,
+		       u8_t unit, knot_callback_t write_cb,
+		       knot_callback_t read_cb);
 
 /*
  * This fuction configures which events should send proxy value to cloud
@@ -37,7 +37,7 @@ int knot_proxy_register(u8_t id, const char *name,
  *
  * This function must end with NULL
  */
-bool knot_proxy_set_config(u8_t id, ...);
+bool knot_data_config(u8_t id, ...);
 
 /* Proxy properties */
 u8_t knot_proxy_get_id(struct knot_proxy *proxy);

--- a/core/src/knot.h
+++ b/core/src/knot.h
@@ -20,11 +20,14 @@ struct knot_proxy;
 
 typedef void (*knot_callback_t) (struct knot_proxy *proxy);
 
-/* Creates & tracks device changes a remote device (cloud) */
-struct knot_proxy *knot_proxy_register(u8_t id, const char *name,
-				       u16_t type_id, u8_t value_type,
-				       u8_t unit, knot_callback_t changed_cb,
-				       knot_callback_t pool_cb);
+/*
+ * Creates & tracks device changes on a remote device (cloud).
+ * Returns the registered id. Returns a negative number if failed.
+ */
+int knot_proxy_register(u8_t id, const char *name,
+			u16_t type_id, u8_t value_type,
+			u8_t unit, knot_callback_t changed_cb,
+			knot_callback_t pool_cb);
 
 /*
  * This fuction configures which events should send proxy value to cloud

--- a/core/src/knot.h
+++ b/core/src/knot.h
@@ -26,8 +26,8 @@ typedef void (*knot_callback_t) (struct knot_proxy *proxy);
  */
 int knot_proxy_register(u8_t id, const char *name,
 			u16_t type_id, u8_t value_type,
-			u8_t unit, knot_callback_t changed_cb,
-			knot_callback_t pool_cb);
+			u8_t unit, knot_callback_t write_cb,
+			knot_callback_t read_cb);
 
 /*
  * This fuction configures which events should send proxy value to cloud

--- a/core/src/proxy.c
+++ b/core/src/proxy.c
@@ -97,10 +97,10 @@ void proxy_stop(void)
 
 }
 
-struct knot_proxy *knot_proxy_register(u8_t id, const char *name,
-				       u16_t type_id, u8_t value_type,
-				       u8_t unit, knot_callback_t changed_cb,
-				       knot_callback_t poll_cb)
+int knot_proxy_register(u8_t id, const char *name,
+			u16_t type_id, u8_t value_type,
+			u8_t unit, knot_callback_t changed_cb,
+			knot_callback_t poll_cb)
 {
 	struct knot_proxy *proxy;
 
@@ -109,21 +109,21 @@ struct knot_proxy *knot_proxy_register(u8_t id, const char *name,
 		LOG_ERR("Register for ID %d failed: "
 			"id >= CONFIG_KNOT_THING_DATA_MAX (%d)",
 			id, CONFIG_KNOT_THING_DATA_MAX);
-		return NULL;
+		return -1;
 	}
 
 	/* Assigned already? */
 	if (proxy_pool[id].id != 0xff) {
 		LOG_ERR("Register for ID %d failed: "
 			"Id already registered", id);
-		return NULL;
+		return -1;
 	}
 
 	/* Basic field validation */
 	if (knot_schema_is_valid(type_id, value_type, unit) != 0 || !name) {
 		LOG_ERR("Register for ID %d failed: "
 			"Invalid schema", id);
-		return NULL;
+		return -1;
 	}
 
 	proxy = &proxy_pool[id];
@@ -149,7 +149,7 @@ struct knot_proxy *knot_proxy_register(u8_t id, const char *name,
 	if (id > last_id || last_id == 0xff)
 		last_id = id;
 
-	return proxy;
+	return id;
 }
 
 bool knot_proxy_set_config(u8_t id, ...)

--- a/core/src/proxy.c
+++ b/core/src/proxy.c
@@ -97,10 +97,10 @@ void proxy_stop(void)
 
 }
 
-int knot_proxy_register(u8_t id, const char *name,
-			u16_t type_id, u8_t value_type,
-			u8_t unit, knot_callback_t write_cb,
-			knot_callback_t read_cb)
+int knot_data_register(u8_t id, const char *name,
+		       u16_t type_id, u8_t value_type,
+		       u8_t unit, knot_callback_t write_cb,
+		       knot_callback_t read_cb)
 {
 	struct knot_proxy *proxy;
 
@@ -152,7 +152,7 @@ int knot_proxy_register(u8_t id, const char *name,
 	return id;
 }
 
-bool knot_proxy_set_config(u8_t id, ...)
+bool knot_data_config(u8_t id, ...)
 {
 	va_list event_args;
 

--- a/core/src/sm.c
+++ b/core/src/sm.c
@@ -375,6 +375,8 @@ static size_t process_cmd(const u8_t *ipdu, size_t ilen,
 			len = msg_create_error(omsg,
 					       KNOT_MSG_PUSH_DATA_RSP,
 					       KNOT_ERR_INVALID);
+			LOG_WRN("Write failed to Id %d", id);
+
 			break;
 		}
 		/* TODO: Change protocol to not require id nor value for


### PR DESCRIPTION
- Simplify API.
- Remove proxy.
- Remove callbacks necessity.
- Update sample apps to the new API.