### PR TITLE
setup: Wait for 2 seconds before resetting

### DIFF
--- a/setup/src/main.c
+++ b/setup/src/main.c
@@ -124,6 +124,7 @@ setup:
 			continue;
 
 		LOG_INF("Reseting system...");
+		k_sleep(2000);
 		sys_reboot(SYS_REBOOT_WARM);
 	}
 }


### PR DESCRIPTION
Wait for 2 seconds before resetting after receiving a reboot command.

This is necessary for bluetooth connections and messages to properly
finish.

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>