### PR TITLE
core: boards: Fix OT area for Dongle debug DTS

### DIFF
--- a/core/boards/nrf52840_pca10059-sub-slots-debug.dts
+++ b/core/boards/nrf52840_pca10059-sub-slots-debug.dts
@@ -34,9 +34,9 @@
 		 * This is allowed as the scratch area is used only
 		 * during OTA update.
 		 */
-		ot_partition: sub-partition@ce000 {
+		ot_partition: sub-partition@d0000 {
 			label = "ot-storage";
-			reg = <0x000ce000 0x00002000>;
+			reg = <0x000d0000 0x00004000>;
 		};
 	};
 };


### PR DESCRIPTION
Moves OT-STORAGE sub-partition from DTS to Scratch area for debug dts
when using nrf52840_pca10059.

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>