### PR TITLE
scripts: cli: Add option allowing the user to provide an external DTS overlay file

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,7 +32,8 @@ if (NOT ${BOARD} STREQUAL qemu_x86)
                 $ENV{KNOT_BASE}/core/boards/overlay-main.dts
         )
         set(DTC_OVERLAY_FILE
-                "${DTC_OVERLAY_FILE} ${DTC_OVERLAY_MULTI_SLOT} ${DTC_OVERLAY_SET_SLOT}"
+                "${DTC_OVERLAY_FILE} ${DTC_OVERLAY_MULTI_SLOT} \
+                 ${DTC_OVERLAY_SET_SLOT} ${DTC_OVERLAY_USER}"
         )
 endif ()
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -143,6 +143,7 @@ class KnotSDK(metaclass=Singleton):
         BOARD_DK = 'nrf52840_pca10056'
         BOARD_MESH = 'knot_mesh'
         BOARD_DONGLE = 'nrf52840_pca10059'
+        BOARDS = [BOARD_DK, BOARD_MESH, BOARD_DONGLE]
         # Using image for dongle while a new image is not built for mesh
         MCUBOOT_STOCK_FILES = {
             BOARD_DK:     'mcuboot-ec-p256-dk.hex',
@@ -152,6 +153,7 @@ class KnotSDK(metaclass=Singleton):
         BOARD_ALIASES = {'dk':     BOARD_DK,
                          'mesh':   BOARD_MESH,
                          'dongle': BOARD_DONGLE}
+        USER_DTS_OVERLAY_FILE = {board: board + '.overlay' for board in BOARDS}
         NRFUTIL_PATH = "third_party/pc-nrfutil/nrfutil"
         SIGN_SCRIPT_PATH = "third_party/mcuboot/scripts/imgtool.py"
         SIGN_KEY_PATH = "third_party/mcuboot/root-ec-p256.pem"
@@ -250,11 +252,20 @@ class KnotSDK(metaclass=Singleton):
 
     def set_ext_dts_ovl_path(self, dts_ovl_path=None):
         """
-        In case of no DTS overlay path passed, keep it as None.
+        Check for a local DTS overlay file if none specified.
+        In case of no DTS overlay path found, keep it as None.
         """
+        user_dts_overlay_path = os.path.join(self.cwd,
+            self.Constants.USER_DTS_OVERLAY_FILE[self.board])
+
         # Use default DTS files if none is passed
         if dts_ovl_path is not None:
             self.ext_dts_ovl_path = dts_ovl_path
+        elif os.path.isfile(user_dts_overlay_path):
+            self.ext_dts_ovl_path = user_dts_overlay_path
+
+        # Log in case of a DTS overlay path found
+        if self.ext_dts_ovl_path is not None:
             logging.info('Using external DTS overlay path: {}'.format(
                 self.ext_dts_ovl_path))
         else:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -118,6 +118,7 @@ class KnotSDK(metaclass=Singleton):
     knot_path = ""  # Common directory and files used by images
     ext_ot_path = None  # External OpenThread repository
     ext_proto_path = None  # External KNoT Protocol repository
+    ext_dts_ovl_path = None  # External DTS overlay file
     cwd = ""  # Current working directory from where cli was called
     setup_app = None  # Setup app
     main_app = None  # Main app
@@ -246,6 +247,19 @@ class KnotSDK(metaclass=Singleton):
             logging.info('Using KNoT Protocol path: {}'.format(self.ext_proto_path))
         else:
             logging.info('No KNoT Protocol path passed')
+
+    def set_ext_dts_ovl_path(self, dts_ovl_path=None):
+        """
+        In case of no DTS overlay path passed, keep it as None.
+        """
+        # Use default DTS files if none is passed
+        if dts_ovl_path is not None:
+            self.ext_dts_ovl_path = dts_ovl_path
+            logging.info('Using external DTS overlay path: {}'.format(
+                self.ext_dts_ovl_path))
+        else:
+            logging.info('No external DTS overlay found. \
+                Using default DTS files')
 
     def print_supported_boards(self):
         """
@@ -468,6 +482,10 @@ or remove the other boards")
             opt +=\
                 ' -DEXTERNAL_PROJECT_PATH_KNOT_PROTOCOL={}'.format(
                     self.ext_proto_path)
+
+        # Use external KNoT Protocol path if provided
+        if self.ext_dts_ovl_path is not None:
+            opt += ' -DDTC_OVERLAY_USER={}'.format(self.ext_dts_ovl_path)
 
         # Debug mode
         if self.debug_app:
@@ -693,6 +711,7 @@ def cli():
 @click.pass_context
 @click.option('--ot_path', help='Define OpenThread repository path')
 @click.option('--proto_path', help='Define KNoT Protocol repository path')
+@click.option('--dts_ovl_path', help='Define a user DTS overlay file path')
 @click.option('-q', '--quiet', help='Suppress successful sub-command messages',
               is_flag=True)
 @click.option('-b', '--board', help='Target board')
@@ -703,7 +722,7 @@ def cli():
               is_flag=True)
 @click.option('-p', '--port', help='Device port')
 @click.option('-o', '--output', help='Output path')
-def make(ctx, ot_path, proto_path, quiet, board, debug,
+def make(ctx, ot_path, proto_path, dts_ovl_path, quiet, board, debug,
          flash, clean, mcuboot, port, output):
     if quiet:
         KnotSDK().set_quiet(True)
@@ -730,6 +749,9 @@ def make(ctx, ot_path, proto_path, quiet, board, debug,
 
     # Defined board required
     KnotSDK().set_board(board=board)
+
+    # Optional external DTS overlay file path
+    KnotSDK().set_ext_dts_ovl_path(dts_ovl_path=dts_ovl_path)
 
     # Make apps
     KnotSDK().make_setup()

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -154,6 +154,8 @@ class KnotSDK(metaclass=Singleton):
                          'mesh':   BOARD_MESH,
                          'dongle': BOARD_DONGLE}
         USER_DTS_OVERLAY_FILE = {board: board + '.overlay' for board in BOARDS}
+        USER_DTS_OVERLAY_FILE_ALIASES = {value: key + '.overlay'
+                                        for key, value in BOARD_ALIASES.items()}
         NRFUTIL_PATH = "third_party/pc-nrfutil/nrfutil"
         SIGN_SCRIPT_PATH = "third_party/mcuboot/scripts/imgtool.py"
         SIGN_KEY_PATH = "third_party/mcuboot/root-ec-p256.pem"
@@ -258,11 +260,16 @@ class KnotSDK(metaclass=Singleton):
         user_dts_overlay_path = os.path.join(self.cwd,
             self.Constants.USER_DTS_OVERLAY_FILE[self.board])
 
+        user_dts_overlay_alias_path = os.path.join(self.cwd,
+            self.Constants.USER_DTS_OVERLAY_FILE_ALIASES[self.board])
+
         # Use default DTS files if none is passed
         if dts_ovl_path is not None:
             self.ext_dts_ovl_path = dts_ovl_path
         elif os.path.isfile(user_dts_overlay_path):
             self.ext_dts_ovl_path = user_dts_overlay_path
+        elif os.path.isfile(user_dts_overlay_alias_path):
+            self.ext_dts_ovl_path = user_dts_overlay_alias_path
 
         # Log in case of a DTS overlay path found
         if self.ext_dts_ovl_path is not None:


### PR DESCRIPTION
Add option `--dts_ovl_path` on `make` command allowing the user to provide an external DTS overlay file path and check for it in the application folder whenever the user does not provide an external path. If the file does not exist, the system will use the default DTS files.

It is not necessary to provide a path in the command line if the file is placed on the root application folder and it is named as `<BOARD>-overlay.dts`.

Closes #62.